### PR TITLE
chore(demo): sync components with Tailwind semantic design tokens

### DIFF
--- a/apps/demo/radish.lock.json
+++ b/apps/demo/radish.lock.json
@@ -3,136 +3,136 @@
     "layout": {
       "files": {
         "layout/layout.tsx": {
-          "registryHash": "sha256-afb44b5b1b02f239df83d6321794e62ec9a3a5e6842e5652d04a7607e8a07217",
-          "localHash": "sha256-afb44b5b1b02f239df83d6321794e62ec9a3a5e6842e5652d04a7607e8a07217"
+          "registryHash": "sha256-bd7b92553a40273cd28f927e17fcf0fe86b9d0375f2fe4a539d13495a4a40d5f",
+          "localHash": "sha256-bd7b92553a40273cd28f927e17fcf0fe86b9d0375f2fe4a539d13495a4a40d5f"
         },
         "layout/sidebar.tsx": {
-          "registryHash": "sha256-c780977875bc73c66ed645578c486228815cd050d308d6f7ad6408eb940687b7",
-          "localHash": "sha256-c780977875bc73c66ed645578c486228815cd050d308d6f7ad6408eb940687b7"
+          "registryHash": "sha256-e39f22a78380f92c9c98927d85909b49d995b6a13bb7c6b268bbbc9cd2a6dea7",
+          "localHash": "sha256-e39f22a78380f92c9c98927d85909b49d995b6a13bb7c6b268bbbc9cd2a6dea7"
         },
         "layout/menu.tsx": {
-          "registryHash": "sha256-18944efca9e9471200aad90e5581424a6b86f5c1075e63909b4e11a3aa63b223",
-          "localHash": "sha256-18944efca9e9471200aad90e5581424a6b86f5c1075e63909b4e11a3aa63b223"
+          "registryHash": "sha256-e463c2404aeb1e462799cb90f4e60c71eb68a579102bf7c3535f72c0b9cadb47",
+          "localHash": "sha256-e463c2404aeb1e462799cb90f4e60c71eb68a579102bf7c3535f72c0b9cadb47"
         },
         "notification/notification.tsx": {
-          "registryHash": "sha256-1515d9adfda65f2c15858559276e4bd061a01a783684632dc09fa3840cd26f0e",
-          "localHash": "sha256-1515d9adfda65f2c15858559276e4bd061a01a783684632dc09fa3840cd26f0e"
+          "registryHash": "sha256-80c3db999be64677aa017d7de518a2fa21d3b4b2d354f29faa5e6b1646c09629",
+          "localHash": "sha256-80c3db999be64677aa017d7de518a2fa21d3b4b2d354f29faa5e6b1646c09629"
         }
       }
     },
     "datagrid": {
       "files": {
         "list/datagrid.tsx": {
-          "registryHash": "sha256-1c9b7effc7363d54e3c7eb64df55945dde8e61a80ee514afaceaccf405714766",
-          "localHash": "sha256-1c9b7effc7363d54e3c7eb64df55945dde8e61a80ee514afaceaccf405714766"
+          "registryHash": "sha256-83c30b7cc723cea32c2187c9be4e7314ab48bc03a77200bba053839509ce94f9",
+          "localHash": "sha256-83c30b7cc723cea32c2187c9be4e7314ab48bc03a77200bba053839509ce94f9"
         },
         "skeleton/skeleton.tsx": {
-          "registryHash": "sha256-eb6fab3f500f0b7316b98b79f400d19edd47c6714f323b98ff3447343ade825d",
-          "localHash": "sha256-eb6fab3f500f0b7316b98b79f400d19edd47c6714f323b98ff3447343ade825d"
+          "registryHash": "sha256-e6500bc5048f7adf331e45aaf4096ed85426c93b3933e204207fe1d029182f20",
+          "localHash": "sha256-e6500bc5048f7adf331e45aaf4096ed85426c93b3933e204207fe1d029182f20"
         }
       }
     },
     "text-field": {
       "files": {
         "field/text-field.tsx": {
-          "registryHash": "sha256-a3664b5c7b5496625301d2c58daa08f3c963c64abe4f7fcbecaef74fd63cc496",
-          "localHash": "sha256-a3664b5c7b5496625301d2c58daa08f3c963c64abe4f7fcbecaef74fd63cc496"
+          "registryHash": "sha256-6ed0f24117a26cb2b79f08871a36e87aee58727b86d47c19fbdf964c283ba5b5",
+          "localHash": "sha256-6ed0f24117a26cb2b79f08871a36e87aee58727b86d47c19fbdf964c283ba5b5"
         }
       }
     },
     "edit-button": {
       "files": {
         "button/edit-button.tsx": {
-          "registryHash": "sha256-4e8c2f47e9fa6648b407772fc1d2d9628a52d50371571956a668d9887cbaaaeb",
-          "localHash": "sha256-4e8c2f47e9fa6648b407772fc1d2d9628a52d50371571956a668d9887cbaaaeb"
+          "registryHash": "sha256-3970a6274e0a165b1f412bd5d7240ea7e202a9b328c1d90d867e49bba1079c41",
+          "localHash": "sha256-3970a6274e0a165b1f412bd5d7240ea7e202a9b328c1d90d867e49bba1079c41"
         }
       }
     },
     "delete-button": {
       "files": {
         "button/delete-button.tsx": {
-          "registryHash": "sha256-023e10865a2f46bd2e0b1ab8b9866ed155e3b78195a153306e47eb64716dc40d",
-          "localHash": "sha256-023e10865a2f46bd2e0b1ab8b9866ed155e3b78195a153306e47eb64716dc40d"
+          "registryHash": "sha256-b7b133e5e11de49554eb780378631f484a41fd9194b30402151e276e3275b8ae",
+          "localHash": "sha256-b7b133e5e11de49554eb780378631f484a41fd9194b30402151e276e3275b8ae"
         }
       }
     },
     "create-button": {
       "files": {
         "button/create-button.tsx": {
-          "registryHash": "sha256-e4f68e6ef4ad832447dd465fd1844130d673c9646cc140275bd858566f1f0900",
-          "localHash": "sha256-e4f68e6ef4ad832447dd465fd1844130d673c9646cc140275bd858566f1f0900"
+          "registryHash": "sha256-12a1ad7ab8b55fb531816b5ebf3b5d3b7116ae97856e462b5a2d6bfd9daaf39d",
+          "localHash": "sha256-12a1ad7ab8b55fb531816b5ebf3b5d3b7116ae97856e462b5a2d6bfd9daaf39d"
         }
       }
     },
     "pagination": {
       "files": {
         "list/pagination.tsx": {
-          "registryHash": "sha256-3657ee5169dcbed636b1d35ca13c27e4ab2c2c59511bc525990e4e1168f2b56f",
-          "localHash": "sha256-3657ee5169dcbed636b1d35ca13c27e4ab2c2c59511bc525990e4e1168f2b56f"
+          "registryHash": "sha256-be83cb59dbc7ced3c190a951c7f0f11ab817d3a400b0a1b97fbfec2074feb1eb",
+          "localHash": "sha256-be83cb59dbc7ced3c190a951c7f0f11ab817d3a400b0a1b97fbfec2074feb1eb"
         }
       }
     },
     "simple-form": {
       "files": {
         "form/simple-form.tsx": {
-          "registryHash": "sha256-e3589af5ecde31bc37127a81c1d803807831e0ab2052114cd7d83de6476302bc",
-          "localHash": "sha256-e3589af5ecde31bc37127a81c1d803807831e0ab2052114cd7d83de6476302bc"
+          "registryHash": "sha256-edab6d3fb6435dfac90fd32cd4d96254ced0355fa97801905734c15d8c68bafa",
+          "localHash": "sha256-edab6d3fb6435dfac90fd32cd4d96254ced0355fa97801905734c15d8c68bafa"
         },
         "form/text-input.tsx": {
-          "registryHash": "sha256-d439aa41ec6d04698fc70b5ac0f68b5e1bb73116b2442e7597d16bbb991ad84e",
-          "localHash": "sha256-d439aa41ec6d04698fc70b5ac0f68b5e1bb73116b2442e7597d16bbb991ad84e"
+          "registryHash": "sha256-9bf2fe36a116f5733ca21a83416b8f207d98b9be586c38fe4d6c051513c7e194",
+          "localHash": "sha256-9bf2fe36a116f5733ca21a83416b8f207d98b9be586c38fe4d6c051513c7e194"
         },
         "form/number-input.tsx": {
-          "registryHash": "sha256-d88295f5d2a3d642e474ee811dbe2707e50eed90fa842ac38af26e34bb5a2f4d",
-          "localHash": "sha256-d88295f5d2a3d642e474ee811dbe2707e50eed90fa842ac38af26e34bb5a2f4d"
+          "registryHash": "sha256-649f6c77ea9c1664de00c6d90613f0c1a2ceb93e0db7f498f4f157d22f09cffc",
+          "localHash": "sha256-649f6c77ea9c1664de00c6d90613f0c1a2ceb93e0db7f498f4f157d22f09cffc"
         },
         "form/select-input.tsx": {
-          "registryHash": "sha256-2160b6f9736cd187003c844621fcfa5217512df5e7c93a9e8dd7fa8697bd4139",
-          "localHash": "sha256-2160b6f9736cd187003c844621fcfa5217512df5e7c93a9e8dd7fa8697bd4139"
+          "registryHash": "sha256-b892fdfbd81f919dfe7a86d760239c7fb07f11c382930ba79fe28b466cd10537",
+          "localHash": "sha256-b892fdfbd81f919dfe7a86d760239c7fb07f11c382930ba79fe28b466cd10537"
         },
         "form/boolean-input.tsx": {
-          "registryHash": "sha256-ec9d4bd48723bff17cd925b664b820995c3270075afe1232d62a6ab83d652c87",
-          "localHash": "sha256-ec9d4bd48723bff17cd925b664b820995c3270075afe1232d62a6ab83d652c87"
+          "registryHash": "sha256-28f4a71b351db00584cd9d0febdf4747e90d6b304009a15f619dc1b73b96e5f9",
+          "localHash": "sha256-28f4a71b351db00584cd9d0febdf4747e90d6b304009a15f619dc1b73b96e5f9"
         }
       }
     },
     "boolean-field": {
       "files": {
         "field/boolean-field.tsx": {
-          "registryHash": "sha256-2432683dc94d2cf80ff541d160911dbba738371be7de507fce9b3ae0ad109ad0",
-          "localHash": "sha256-2432683dc94d2cf80ff541d160911dbba738371be7de507fce9b3ae0ad109ad0"
+          "registryHash": "sha256-35b49f7be305ce2b0336216687b7e81ef25375c5f3147729f3d54703f63b9647",
+          "localHash": "sha256-35b49f7be305ce2b0336216687b7e81ef25375c5f3147729f3d54703f63b9647"
         }
       }
     },
     "number-field": {
       "files": {
         "field/number-field.tsx": {
-          "registryHash": "sha256-6c03dad34b71068205d9fd730a6518157c8e533ebcb10e5ff6d46d65736c5029",
-          "localHash": "sha256-6c03dad34b71068205d9fd730a6518157c8e533ebcb10e5ff6d46d65736c5029"
+          "registryHash": "sha256-f80ff4dfa87996ee73c8913600d51d3db9aec516bec8831284f3eb0812631140",
+          "localHash": "sha256-f80ff4dfa87996ee73c8913600d51d3db9aec516bec8831284f3eb0812631140"
         }
       }
     },
     "date-field": {
       "files": {
         "field/date-field.tsx": {
-          "registryHash": "sha256-527a78c9ff12eecb015e26a653d4a22b3650fcb20f26d482cc2f859ac6f5aab5",
-          "localHash": "sha256-527a78c9ff12eecb015e26a653d4a22b3650fcb20f26d482cc2f859ac6f5aab5"
+          "registryHash": "sha256-ebe22114201fa9630411ea6a126adf7130402c8d1f828bb4db89fae65fae0dac",
+          "localHash": "sha256-ebe22114201fa9630411ea6a126adf7130402c8d1f828bb4db89fae65fae0dac"
         }
       }
     },
     "list": {
       "files": {
         "list/list.tsx": {
-          "registryHash": "sha256-5d90a2de6fa96ace61ce9ae9d11c2627160543762a2ac3e1bd8c87421bc01b13",
-          "localHash": "sha256-5d90a2de6fa96ace61ce9ae9d11c2627160543762a2ac3e1bd8c87421bc01b13"
+          "registryHash": "sha256-8feb0534ca980bf1d240c3d7aecf555b673b6639f672d11305904a3ea125c090",
+          "localHash": "sha256-8feb0534ca980bf1d240c3d7aecf555b673b6639f672d11305904a3ea125c090"
         }
       }
     },
     "edit": {
       "files": {
         "detail/edit.tsx": {
-          "registryHash": "sha256-7f53ce5271a3c7ad3dfe38d884bc092ac87db0f0fdfbccc5e73c8e5674f0c82b",
-          "localHash": "sha256-7f53ce5271a3c7ad3dfe38d884bc092ac87db0f0fdfbccc5e73c8e5674f0c82b"
+          "registryHash": "sha256-d47f7cb1a1e0efb3c30321113989bf57e8c2abb712f2f271c160ebef6be5e1e1",
+          "localHash": "sha256-d47f7cb1a1e0efb3c30321113989bf57e8c2abb712f2f271c160ebef6be5e1e1"
         },
         "skeleton/skeleton.tsx": {
           "registryHash": "sha256-eb6fab3f500f0b7316b98b79f400d19edd47c6714f323b98ff3447343ade825d",
@@ -143,20 +143,20 @@
     "create": {
       "files": {
         "detail/create.tsx": {
-          "registryHash": "sha256-a0dd91636451373c2237d9a2f4ca23f83d2ff9c1cd140e214c25b7a4780b5bd9",
-          "localHash": "sha256-a0dd91636451373c2237d9a2f4ca23f83d2ff9c1cd140e214c25b7a4780b5bd9"
+          "registryHash": "sha256-bfa6e19de71a85a91fa4ee31a31418d7539ce0f37b51535b05889dd1eddc97f5",
+          "localHash": "sha256-bfa6e19de71a85a91fa4ee31a31418d7539ce0f37b51535b05889dd1eddc97f5"
         }
       }
     },
     "show": {
       "files": {
         "detail/show.tsx": {
-          "registryHash": "sha256-808a5c2571d80b1cdcbd99ff45b932a29bc12873fbcdc50415854133e7aaeba7",
-          "localHash": "sha256-808a5c2571d80b1cdcbd99ff45b932a29bc12873fbcdc50415854133e7aaeba7"
+          "registryHash": "sha256-96712f1a69cd4cbf2f01211f79532949ccb1c6199cf0f934fe3bf7068c53d273",
+          "localHash": "sha256-96712f1a69cd4cbf2f01211f79532949ccb1c6199cf0f934fe3bf7068c53d273"
         },
         "detail/simple-show-layout.tsx": {
-          "registryHash": "sha256-ccd5ca356e91a0424d7c99d063d411d99967df3a1f91187ae579e0a96d67491f",
-          "localHash": "sha256-ccd5ca356e91a0424d7c99d063d411d99967df3a1f91187ae579e0a96d67491f"
+          "registryHash": "sha256-a36474642fcee9627268ddc40ca42ec580f46627ef8e84d7235474a39df86ea6",
+          "localHash": "sha256-a36474642fcee9627268ddc40ca42ec580f46627ef8e84d7235474a39df86ea6"
         },
         "skeleton/skeleton.tsx": {
           "registryHash": "sha256-eb6fab3f500f0b7316b98b79f400d19edd47c6714f323b98ff3447343ade825d",

--- a/apps/demo/src/components/button/create-button.tsx
+++ b/apps/demo/src/components/button/create-button.tsx
@@ -30,7 +30,7 @@ export function CreateButton({ resource, label = "Create", className }: CreateBu
     <Link
       to={path}
       className={cn(
-        "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 transition-colors",
+        "inline-flex items-center rounded-md bg-primary-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 transition-colors",
         className,
       )}
     >

--- a/apps/demo/src/components/button/delete-button.tsx
+++ b/apps/demo/src/components/button/delete-button.tsx
@@ -52,8 +52,8 @@ export function DeleteButton({
       onClick={onClick}
       disabled={isPending}
       className={cn(
-        "inline-flex items-center rounded-md px-2.5 py-1.5 text-xs font-medium text-red-600 hover:bg-red-50 hover:text-red-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
-        "dark:text-red-400 dark:hover:bg-red-900/30 dark:hover:text-red-300",
+        "inline-flex items-center rounded-md px-2.5 py-1.5 text-xs font-medium text-danger-600 hover:bg-danger-50 hover:text-danger-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
+        "dark:text-danger-400 dark:hover:bg-danger-900/30 dark:hover:text-danger-300",
         className,
       )}
     >

--- a/apps/demo/src/components/button/edit-button.tsx
+++ b/apps/demo/src/components/button/edit-button.tsx
@@ -38,8 +38,8 @@ export function EditButton({ resource, label = "Edit", className }: EditButtonPr
     <Link
       to={path}
       className={cn(
-        "inline-flex items-center rounded-md px-2.5 py-1.5 text-xs font-medium text-indigo-600 hover:bg-indigo-50 hover:text-indigo-800 transition-colors",
-        "dark:text-indigo-400 dark:hover:bg-indigo-900/30 dark:hover:text-indigo-300",
+        "inline-flex items-center rounded-md px-2.5 py-1.5 text-xs font-medium text-primary-600 hover:bg-primary-50 hover:text-primary-800 transition-colors",
+        "dark:text-primary-400 dark:hover:bg-primary-900/30 dark:hover:text-primary-300",
         className,
       )}
     >

--- a/apps/demo/src/components/detail/create.tsx
+++ b/apps/demo/src/components/detail/create.tsx
@@ -104,7 +104,9 @@ function CreateLayout({ children, actions, aside, title, className }: CreateLayo
     <div className={cn("space-y-4", className)}>
       <div className="flex items-center justify-between">
         {displayTitle && (
-          <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">{displayTitle}</h1>
+          <h1 className="text-2xl font-bold text-neutral-800 dark:text-neutral-100">
+            {displayTitle}
+          </h1>
         )}
         {actions && <div>{actions}</div>}
       </div>

--- a/apps/demo/src/components/detail/edit.tsx
+++ b/apps/demo/src/components/detail/edit.tsx
@@ -124,7 +124,7 @@ function EditLayout({
 
   if (error) {
     return (
-      <div className="rounded-md bg-red-50 dark:bg-red-900/20 p-4 text-sm text-red-700 dark:text-red-400">
+      <div className="rounded-md bg-danger-50 dark:bg-danger-900/20 p-4 text-sm text-danger-700 dark:text-danger-400">
         <strong>Error loading record:</strong>{" "}
         {error instanceof Error ? error.message : String(error)}
       </div>
@@ -143,7 +143,7 @@ function EditLayout({
           {actions && <Skeleton className="h-8 w-24" />}
         </div>
         <div className="flex gap-4">
-          <div className="flex-1 rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-6 shadow-sm">
+          <div className="flex-1 rounded-lg border border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800 p-6 shadow-sm">
             <div className="space-y-5">
               {Array.from({ length: 4 }).map((_, i) => (
                 <div key={i} className="space-y-1.5">
@@ -166,7 +166,9 @@ function EditLayout({
     <div className={cn("space-y-4", className)}>
       <div className="flex items-center justify-between">
         {displayTitle && (
-          <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">{displayTitle}</h1>
+          <h1 className="text-2xl font-bold text-neutral-800 dark:text-neutral-100">
+            {displayTitle}
+          </h1>
         )}
         {actions && <div>{actions}</div>}
       </div>

--- a/apps/demo/src/components/detail/show.tsx
+++ b/apps/demo/src/components/detail/show.tsx
@@ -92,7 +92,7 @@ function ShowLayout({
 
   if (error) {
     return (
-      <div className="rounded-md bg-red-50 dark:bg-red-900/20 p-4 text-sm text-red-700 dark:text-red-400">
+      <div className="rounded-md bg-danger-50 dark:bg-danger-900/20 p-4 text-sm text-danger-700 dark:text-danger-400">
         <strong>Error loading record:</strong>{" "}
         {error instanceof Error ? error.message : String(error)}
       </div>
@@ -111,8 +111,8 @@ function ShowLayout({
           {actions && <Skeleton className="h-8 w-24" />}
         </div>
         <div className="flex gap-4">
-          <div className="flex-1 rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 shadow-sm">
-            <dl className="divide-y divide-gray-100 dark:divide-gray-700">
+          <div className="flex-1 rounded-lg border border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800 shadow-sm">
+            <dl className="divide-y divide-neutral-100 dark:divide-neutral-700">
               {Array.from({ length: 4 }).map((_, i) => (
                 <div key={i} className="px-6 py-4 sm:grid sm:grid-cols-3 sm:gap-4">
                   <Skeleton className="h-4 w-24" />
@@ -133,7 +133,9 @@ function ShowLayout({
     <div className={cn("space-y-4", className)}>
       <div className="flex items-center justify-between">
         {displayTitle && (
-          <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">{displayTitle}</h1>
+          <h1 className="text-2xl font-bold text-neutral-800 dark:text-neutral-100">
+            {displayTitle}
+          </h1>
         )}
         {actions && <div>{actions}</div>}
       </div>

--- a/apps/demo/src/components/detail/simple-show-layout.tsx
+++ b/apps/demo/src/components/detail/simple-show-layout.tsx
@@ -30,11 +30,11 @@ export function SimpleShowLayout({ children, className }: SimpleShowLayoutProps)
   return (
     <div
       className={cn(
-        "rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800",
+        "rounded-lg border border-neutral-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-800",
         className,
       )}
     >
-      <dl className="divide-y divide-gray-100 dark:divide-gray-700">
+      <dl className="divide-y divide-neutral-100 dark:divide-neutral-700">
         {fields.map((field, i) => {
           const label =
             field.props.label ??
@@ -45,8 +45,10 @@ export function SimpleShowLayout({ children, className }: SimpleShowLayoutProps)
               key={field.props.source ?? i}
               className="px-6 py-4 sm:grid sm:grid-cols-3 sm:gap-4"
             >
-              <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">{label}</dt>
-              <dd className="mt-1 text-sm text-gray-900 dark:text-gray-100 sm:col-span-2 sm:mt-0">
+              <dt className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
+                {label}
+              </dt>
+              <dd className="mt-1 text-sm text-neutral-900 dark:text-neutral-100 sm:col-span-2 sm:mt-0">
                 {field}
               </dd>
             </div>

--- a/apps/demo/src/components/field/boolean-field.tsx
+++ b/apps/demo/src/components/field/boolean-field.tsx
@@ -33,8 +33,8 @@ export function BooleanField({
       className={cn(
         "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
         isTrue
-          ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-          : "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400",
+          ? "bg-success-100 text-success-800 dark:bg-success-900/30 dark:text-success-400"
+          : "bg-neutral-100 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-400",
         className,
       )}
       aria-label={isTrue ? trueLabel : falseLabel}

--- a/apps/demo/src/components/field/date-field.tsx
+++ b/apps/demo/src/components/field/date-field.tsx
@@ -34,14 +34,16 @@ export function DateField({
   const value = useFieldValue({ source });
 
   if (value == null || value === "") {
-    return <span className={cn("text-sm text-gray-400 dark:text-gray-500", className)}>—</span>;
+    return (
+      <span className={cn("text-sm text-neutral-400 dark:text-neutral-500", className)}>—</span>
+    );
   }
 
   const date = value instanceof Date ? value : new Date(value as string | number);
 
   if (isNaN(date.getTime())) {
     return (
-      <span className={cn("text-sm text-gray-700 dark:text-gray-300", className)}>
+      <span className={cn("text-sm text-neutral-700 dark:text-neutral-300", className)}>
         {String(value)}
       </span>
     );
@@ -59,7 +61,7 @@ export function DateField({
   return (
     <time
       dateTime={date.toISOString()}
-      className={cn("text-sm text-gray-700 dark:text-gray-300", className)}
+      className={cn("text-sm text-neutral-700 dark:text-neutral-300", className)}
     >
       {formatted}
     </time>

--- a/apps/demo/src/components/field/number-field.tsx
+++ b/apps/demo/src/components/field/number-field.tsx
@@ -24,13 +24,15 @@ export function NumberField({ source, options, locales, className }: NumberField
   const value = useFieldValue({ source });
 
   if (value == null) {
-    return <span className={cn("text-sm text-gray-400 dark:text-gray-500", className)}>—</span>;
+    return (
+      <span className={cn("text-sm text-neutral-400 dark:text-neutral-500", className)}>—</span>
+    );
   }
 
   const num = Number(value);
   if (isNaN(num)) {
     return (
-      <span className={cn("text-sm text-gray-700 dark:text-gray-300", className)}>
+      <span className={cn("text-sm text-neutral-700 dark:text-neutral-300", className)}>
         {String(value)}
       </span>
     );
@@ -39,7 +41,7 @@ export function NumberField({ source, options, locales, className }: NumberField
   const formatted = new Intl.NumberFormat(locales, options).format(num);
 
   return (
-    <span className={cn("text-sm text-gray-700 dark:text-gray-300 tabular-nums", className)}>
+    <span className={cn("text-sm text-neutral-700 dark:text-neutral-300 tabular-nums", className)}>
       {formatted}
     </span>
   );

--- a/apps/demo/src/components/field/text-field.tsx
+++ b/apps/demo/src/components/field/text-field.tsx
@@ -19,7 +19,7 @@ interface TextFieldProps {
 export function TextField({ source, className }: TextFieldProps) {
   const value = useFieldValue({ source });
   return (
-    <span className={cn("text-sm text-gray-700 dark:text-gray-300", className)}>
+    <span className={cn("text-sm text-neutral-700 dark:text-neutral-300", className)}>
       {value !== undefined && value !== null ? String(value) : "—"}
     </span>
   );

--- a/apps/demo/src/components/form/boolean-input.tsx
+++ b/apps/demo/src/components/form/boolean-input.tsx
@@ -44,19 +44,19 @@ export function BooleanInput({ source, label, className }: BooleanInputProps) {
           checked={!!value}
           onChange={(e) => onChange(e.target.checked)}
           onBlur={onBlur}
-          className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-400"
+          className="h-4 w-4 rounded border-neutral-300 dark:border-neutral-600 text-primary-600 focus:ring-primary-500 dark:focus:ring-primary-400"
         />
-        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
           {fieldLabel}
           {isRequired && (
-            <span className="text-red-500 ml-1" aria-hidden>
+            <span className="text-danger-500 ml-1" aria-hidden>
               *
             </span>
           )}
         </span>
       </label>
       {error && (
-        <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+        <p className="mt-1 text-xs text-danger-600 dark:text-danger-400" role="alert">
           {error.message}
         </p>
       )}

--- a/apps/demo/src/components/form/number-input.tsx
+++ b/apps/demo/src/components/form/number-input.tsx
@@ -54,11 +54,11 @@ export function NumberInput({
     <div>
       <label
         htmlFor={id}
-        className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1"
       >
         {fieldLabel}
         {isRequired && (
-          <span className="text-red-500 ml-1" aria-hidden>
+          <span className="text-danger-500 ml-1" aria-hidden>
             *
           </span>
         )}
@@ -72,18 +72,18 @@ export function NumberInput({
         max={max}
         step={step}
         className={cn(
-          "block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm",
-          "placeholder:text-gray-400",
-          "focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500",
-          "dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder:text-gray-500",
-          "dark:focus:border-indigo-400 dark:focus:ring-indigo-400",
+          "block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 shadow-sm",
+          "placeholder:text-neutral-400",
+          "focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500",
+          "dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-100 dark:placeholder:text-neutral-500",
+          "dark:focus:border-primary-400 dark:focus:ring-primary-400",
           error &&
-            "border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-400 dark:focus:border-red-400 dark:focus:ring-red-400",
+            "border-danger-500 focus:border-danger-500 focus:ring-danger-500 dark:border-danger-400 dark:focus:border-danger-400 dark:focus:ring-danger-400",
           className,
         )}
       />
       {error && (
-        <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+        <p className="mt-1 text-xs text-danger-600 dark:text-danger-400" role="alert">
           {error.message}
         </p>
       )}

--- a/apps/demo/src/components/form/select-input.tsx
+++ b/apps/demo/src/components/form/select-input.tsx
@@ -58,11 +58,11 @@ export function SelectInput({
     <div>
       <label
         htmlFor={id}
-        className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1"
       >
         {fieldLabel}
         {isRequired && (
-          <span className="text-red-500 ml-1" aria-hidden>
+          <span className="text-danger-500 ml-1" aria-hidden>
             *
           </span>
         )}
@@ -71,12 +71,12 @@ export function SelectInput({
         {...field}
         id={id}
         className={cn(
-          "block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm",
-          "focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500",
-          "dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100",
-          "dark:focus:border-indigo-400 dark:focus:ring-indigo-400",
+          "block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 shadow-sm",
+          "focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500",
+          "dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-100",
+          "dark:focus:border-primary-400 dark:focus:ring-primary-400",
           error &&
-            "border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-400 dark:focus:border-red-400 dark:focus:ring-red-400",
+            "border-danger-500 focus:border-danger-500 focus:ring-danger-500 dark:border-danger-400 dark:focus:border-danger-400 dark:focus:ring-danger-400",
           className,
         )}
       >
@@ -88,7 +88,7 @@ export function SelectInput({
         ))}
       </select>
       {error && (
-        <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+        <p className="mt-1 text-xs text-danger-600 dark:text-danger-400" role="alert">
           {error.message}
         </p>
       )}

--- a/apps/demo/src/components/form/simple-form.tsx
+++ b/apps/demo/src/components/form/simple-form.tsx
@@ -51,16 +51,16 @@ function SimpleFormContent({
   return (
     <div
       className={cn(
-        "rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800",
+        "rounded-lg border border-neutral-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-800",
         className,
       )}
     >
       <div className="space-y-5 px-6 py-6">{children}</div>
-      <div className="flex items-center justify-end gap-3 border-t border-gray-100 dark:border-gray-700 px-6 py-4">
+      <div className="flex items-center justify-end gap-3 border-t border-neutral-100 dark:border-neutral-700 px-6 py-4">
         <button
           type="submit"
           disabled={saving}
-          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           {saving ? "Saving…" : submitLabel}
         </button>

--- a/apps/demo/src/components/form/text-input.tsx
+++ b/apps/demo/src/components/form/text-input.tsx
@@ -42,13 +42,13 @@ export function TextInput({
 
   const fieldLabel = label ?? capitalize(source);
   const sharedClassName = cn(
-    "block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm",
-    "placeholder:text-gray-400",
-    "focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500",
-    "dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder:text-gray-500",
-    "dark:focus:border-indigo-400 dark:focus:ring-indigo-400",
+    "block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 shadow-sm",
+    "placeholder:text-neutral-400",
+    "focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500",
+    "dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-100 dark:placeholder:text-neutral-500",
+    "dark:focus:border-primary-400 dark:focus:ring-primary-400",
     error &&
-      "border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-400 dark:focus:border-red-400 dark:focus:ring-red-400",
+      "border-danger-500 focus:border-danger-500 focus:ring-danger-500 dark:border-danger-400 dark:focus:border-danger-400 dark:focus:ring-danger-400",
     className,
   );
 
@@ -56,11 +56,11 @@ export function TextInput({
     <div>
       <label
         htmlFor={id}
-        className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1"
       >
         {fieldLabel}
         {isRequired && (
-          <span className="text-red-500 ml-1" aria-hidden>
+          <span className="text-danger-500 ml-1" aria-hidden>
             *
           </span>
         )}
@@ -83,7 +83,7 @@ export function TextInput({
         />
       )}
       {error && (
-        <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+        <p className="mt-1 text-xs text-danger-600 dark:text-danger-400" role="alert">
           {error.message}
         </p>
       )}

--- a/apps/demo/src/components/layout/layout.tsx
+++ b/apps/demo/src/components/layout/layout.tsx
@@ -43,9 +43,9 @@ export function Layout({ children, title }: LayoutProps) {
   }, [darkMode]);
 
   return (
-    <div className="flex h-screen flex-col bg-gray-100 dark:bg-gray-900">
+    <div className="flex h-screen flex-col bg-neutral-100 dark:bg-neutral-900">
       {/* Header */}
-      <header className="flex h-12 shrink-0 items-center bg-indigo-700 dark:bg-indigo-900 px-4 shadow">
+      <header className="flex h-12 shrink-0 items-center bg-primary-700 dark:bg-primary-900 px-4 shadow">
         <span className="text-lg font-semibold text-white">{title ?? "radish-ui"}</span>
 
         {/* Dark mode toggle */}

--- a/apps/demo/src/components/layout/menu.tsx
+++ b/apps/demo/src/components/layout/menu.tsx
@@ -27,10 +27,10 @@ export function Menu({ open = true, className }: MenuProps) {
             <li key={name}>
               <a
                 href={path}
-                className="flex items-center gap-3 rounded-md px-2 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white transition-colors"
+                className="flex items-center gap-3 rounded-md px-2 py-2 text-sm font-medium text-neutral-300 hover:bg-neutral-700 hover:text-white transition-colors"
               >
                 {/* Resource icon placeholder */}
-                <span className="inline-block h-4 w-4 rounded-sm bg-indigo-500 shrink-0" />
+                <span className="inline-block h-4 w-4 rounded-sm bg-primary-500 shrink-0" />
                 {open && (
                   <span className="truncate capitalize">{resource.options?.label ?? name}</span>
                 )}

--- a/apps/demo/src/components/layout/sidebar.tsx
+++ b/apps/demo/src/components/layout/sidebar.tsx
@@ -18,14 +18,14 @@ export function Sidebar({ open, onToggle, children }: SidebarProps) {
   return (
     <aside
       className={cn(
-        "flex flex-col bg-gray-900 dark:bg-gray-950 text-white transition-all duration-200",
+        "flex flex-col bg-neutral-900 dark:bg-neutral-950 text-white transition-all duration-200",
         open ? "w-56" : "w-14",
       )}
     >
       {/* Toggle button */}
       <button
         onClick={onToggle}
-        className="flex items-center justify-center h-12 w-full text-gray-400 hover:text-white hover:bg-gray-800 dark:hover:bg-gray-700 transition-colors"
+        className="flex items-center justify-center h-12 w-full text-neutral-400 hover:text-white hover:bg-neutral-800 dark:hover:bg-neutral-700 transition-colors"
         aria-label={open ? "Collapse sidebar" : "Expand sidebar"}
       >
         <MdMenu size={22} />

--- a/apps/demo/src/components/list/datagrid.tsx
+++ b/apps/demo/src/components/list/datagrid.tsx
@@ -39,15 +39,15 @@ export function Datagrid({ children, rowActions, className }: DatagridProps) {
       <SkeletonContainer
         label="Loading table data…"
         className={cn(
-          "overflow-x-auto rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800",
+          "overflow-x-auto rounded-lg border border-neutral-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-800",
           className,
         )}
       >
         <table
           aria-hidden="true"
-          className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm"
+          className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700 text-sm"
         >
-          <thead className="bg-gray-50 dark:bg-gray-700">
+          <thead className="bg-neutral-50 dark:bg-neutral-700">
             <tr>
               {columns.map((col, i) => {
                 const header =
@@ -57,7 +57,7 @@ export function Datagrid({ children, rowActions, className }: DatagridProps) {
                   <th
                     key={col.props.source ?? i}
                     scope="col"
-                    className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                    className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400"
                   >
                     {header}
                   </th>
@@ -66,14 +66,14 @@ export function Datagrid({ children, rowActions, className }: DatagridProps) {
               {rowActions && (
                 <th
                   scope="col"
-                  className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                  className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400"
                 >
                   Actions
                 </th>
               )}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+          <tbody className="divide-y divide-neutral-100 dark:divide-neutral-700">
             {Array.from({ length: 5 }).map((_, rowIdx) => (
               <tr key={rowIdx}>
                 {columns.map((col, colIdx) => (
@@ -96,7 +96,7 @@ export function Datagrid({ children, rowActions, className }: DatagridProps) {
 
   if (!data || data.length === 0) {
     return (
-      <div className="flex items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+      <div className="flex items-center justify-center py-12 text-neutral-400 dark:text-neutral-500">
         No records found.
       </div>
     );
@@ -105,12 +105,12 @@ export function Datagrid({ children, rowActions, className }: DatagridProps) {
   return (
     <div
       className={cn(
-        "overflow-x-auto rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800",
+        "overflow-x-auto rounded-lg border border-neutral-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-800",
         className,
       )}
     >
-      <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
-        <thead className="bg-gray-50 dark:bg-gray-700">
+      <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700 text-sm">
+        <thead className="bg-neutral-50 dark:bg-neutral-700">
           <tr>
             {columns.map((col, i) => {
               const header =
@@ -120,7 +120,7 @@ export function Datagrid({ children, rowActions, className }: DatagridProps) {
                 <th
                   key={col.props.source ?? i}
                   scope="col"
-                  className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                  className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400"
                 >
                   {header}
                 </th>
@@ -129,21 +129,21 @@ export function Datagrid({ children, rowActions, className }: DatagridProps) {
             {rowActions && (
               <th
                 scope="col"
-                className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400"
               >
                 Actions
               </th>
             )}
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+        <tbody className="divide-y divide-neutral-100 dark:divide-neutral-700">
           {data.map((record) => (
             <RecordContextProvider key={record.id} value={record}>
-              <tr className="hover:bg-indigo-50 dark:hover:bg-indigo-900/30 transition-colors">
+              <tr className="hover:bg-primary-50 dark:hover:bg-primary-900/30 transition-colors">
                 {columns.map((col, i) => (
                   <td
                     key={col.props.source ?? i}
-                    className="px-4 py-3 text-gray-700 dark:text-gray-300"
+                    className="px-4 py-3 text-neutral-700 dark:text-neutral-300"
                   >
                     {col}
                   </td>

--- a/apps/demo/src/components/list/list.tsx
+++ b/apps/demo/src/components/list/list.tsx
@@ -138,7 +138,7 @@ export function ListLayout({
 
   if (error) {
     return (
-      <div className="rounded-md bg-red-50 dark:bg-red-900/20 p-4 text-sm text-red-700 dark:text-red-400">
+      <div className="rounded-md bg-danger-50 dark:bg-danger-900/20 p-4 text-sm text-danger-700 dark:text-danger-400">
         <strong>Error loading data:</strong>{" "}
         {error instanceof Error ? error.message : String(error)}
       </div>
@@ -157,7 +157,9 @@ export function ListLayout({
       {/* Page header */}
       <div className="flex items-center justify-between">
         {displayTitle && (
-          <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">{displayTitle}</h1>
+          <h1 className="text-2xl font-bold text-neutral-800 dark:text-neutral-100">
+            {displayTitle}
+          </h1>
         )}
         {actions && <div>{actions}</div>}
       </div>
@@ -172,7 +174,7 @@ export function ListLayout({
             empty != null ? (
               <>{empty}</>
             ) : (
-              <div className="py-12 text-center text-gray-500 dark:text-gray-400">
+              <div className="py-12 text-center text-neutral-500 dark:text-neutral-400">
                 No records found.
               </div>
             )
@@ -184,7 +186,7 @@ export function ListLayout({
       </div>
 
       {pagination && (
-        <div className="border-t border-gray-100 dark:border-gray-800 pt-3">{pagination}</div>
+        <div className="border-t border-neutral-100 dark:border-neutral-800 pt-3">{pagination}</div>
       )}
     </div>
   );

--- a/apps/demo/src/components/list/pagination.tsx
+++ b/apps/demo/src/components/list/pagination.tsx
@@ -33,7 +33,7 @@ export function Pagination({ siblingCount = 2, className }: PaginationProps) {
       aria-label="Pagination"
       className={cn("flex items-center justify-between px-1 py-3 text-sm", className)}
     >
-      <p className="text-gray-500 dark:text-gray-400">
+      <p className="text-neutral-500 dark:text-neutral-400">
         {total} result{total !== 1 ? "s" : ""}
       </p>
 
@@ -43,7 +43,7 @@ export function Pagination({ siblingCount = 2, className }: PaginationProps) {
           <button
             onClick={() => setPage(page - 1)}
             disabled={page <= 1}
-            className="rounded-md px-3 py-1.5 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            className="rounded-md px-3 py-1.5 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             aria-label="Previous page"
           >
             ‹
@@ -52,7 +52,10 @@ export function Pagination({ siblingCount = 2, className }: PaginationProps) {
 
         {pages.map((p, i) =>
           p === "…" ? (
-            <li key={`ellipsis-${i}`} className="px-2 text-gray-400 dark:text-gray-500 select-none">
+            <li
+              key={`ellipsis-${i}`}
+              className="px-2 text-neutral-400 dark:text-neutral-500 select-none"
+            >
               …
             </li>
           ) : (
@@ -63,8 +66,8 @@ export function Pagination({ siblingCount = 2, className }: PaginationProps) {
                 className={cn(
                   "rounded-md px-3 py-1.5 transition-colors",
                   p === page
-                    ? "bg-indigo-600 text-white font-semibold"
-                    : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700",
+                    ? "bg-primary-600 text-white font-semibold"
+                    : "text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700",
                 )}
               >
                 {p}
@@ -78,7 +81,7 @@ export function Pagination({ siblingCount = 2, className }: PaginationProps) {
           <button
             onClick={() => setPage(page + 1)}
             disabled={page >= pageCount}
-            className="rounded-md px-3 py-1.5 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            className="rounded-md px-3 py-1.5 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             aria-label="Next page"
           >
             ›

--- a/apps/demo/src/components/notification/notification.tsx
+++ b/apps/demo/src/components/notification/notification.tsx
@@ -17,9 +17,9 @@ interface ActiveNotification extends NotificationPayload {
 
 const typeStyles: Record<NotificationType, string> = {
   success:
-    "bg-green-50 border-green-400 text-green-800 [&_[data-icon]]:text-green-500 dark:bg-green-900/30 dark:border-green-700 dark:text-green-300 dark:[&_[data-icon]]:text-green-400",
+    "bg-success-50 border-success-400 text-success-800 [&_[data-icon]]:text-success-500 dark:bg-success-900/30 dark:border-success-700 dark:text-success-300 dark:[&_[data-icon]]:text-success-400",
   error:
-    "bg-red-50 border-red-400 text-red-800 [&_[data-icon]]:text-red-500 dark:bg-red-900/30 dark:border-red-700 dark:text-red-300 dark:[&_[data-icon]]:text-red-400",
+    "bg-danger-50 border-danger-400 text-danger-800 [&_[data-icon]]:text-danger-500 dark:bg-danger-900/30 dark:border-danger-700 dark:text-danger-300 dark:[&_[data-icon]]:text-danger-400",
   info: "bg-blue-50 border-blue-400 text-blue-800 [&_[data-icon]]:text-blue-500 dark:bg-blue-900/30 dark:border-blue-700 dark:text-blue-300 dark:[&_[data-icon]]:text-blue-400",
   warning:
     "bg-yellow-50 border-yellow-400 text-yellow-800 [&_[data-icon]]:text-yellow-500 dark:bg-yellow-900/30 dark:border-yellow-700 dark:text-yellow-300 dark:[&_[data-icon]]:text-yellow-400",

--- a/apps/demo/src/components/skeleton/skeleton.tsx
+++ b/apps/demo/src/components/skeleton/skeleton.tsx
@@ -51,7 +51,7 @@ export function Skeleton({ label, className }: SkeletonProps) {
       <div
         role="status"
         aria-live="polite"
-        className={cn("animate-pulse rounded-md bg-gray-200 dark:bg-gray-700", className)}
+        className={cn("animate-pulse rounded-md bg-neutral-200 dark:bg-neutral-700", className)}
       >
         <span className="sr-only">{label}</span>
       </div>
@@ -60,7 +60,7 @@ export function Skeleton({ label, className }: SkeletonProps) {
   return (
     <div
       aria-hidden="true"
-      className={cn("animate-pulse rounded-md bg-gray-200 dark:bg-gray-700", className)}
+      className={cn("animate-pulse rounded-md bg-neutral-200 dark:bg-neutral-700", className)}
     />
   );
 }


### PR DESCRIPTION
Updates all copied registry components in the demo app to use the new semantic color tokens (primary-*, neutral-*, success-*, danger-*) introduced by the Tailwind preset in #54. Also refreshes radish.lock.json hashes to reflect the current registry state.