### PR TITLE
Update RELEASING.md with new guidelines and structure.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,7 +39,7 @@ Once this is set up, the publish workflow runs automatically on every GitHub Rel
 
 ### Friendly reminder: you still need a "release prep" PR
 
-CI takes care of *publishing*, but it doesn’t magically know what version you want to ship or what should go in the release notes. Before you publish a GitHub Release, open and merge a small "release prep" PR to get the repo into a releasable state.
+CI takes care of _publishing_, but it doesn’t magically know what version you want to ship or what should go in the release notes. Before you publish a GitHub Release, open and merge a small "release prep" PR to get the repo into a releasable state.
 
 **Release prep PR checklist:**
 
@@ -51,6 +51,7 @@ CI takes care of *publishing*, but it doesn’t magically know what version you 
     ```
 
   - Update the compare links at the bottom of the file.
+
 - [ ] Bump versions in:
   - `packages/core/package.json`
   - `packages/cli/package.json`


### PR DESCRIPTION
This pull request improves the `RELEASING.md` documentation by restructuring it for clarity and completeness, with a focus on making the release process easier to follow for both automated and manual publishing. The most important changes are:

**Documentation structure and clarity:**

* Added a detailed table of contents to improve navigation and readability.
* Reformatted and clarified instructions throughout the document, consolidating and simplifying explanations for both automated and manual release processes. [[1]](diffhunk://#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785dR5-R29) [[2]](diffhunk://#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785dL35-R96) [[3]](diffhunk://#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785dL70-R126) [[4]](diffhunk://#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785dL102-R142) [[5]](diffhunk://#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785dL131-R161)

**Automated publishing process:**

* Added a new "Friendly reminder: you still need a 'release prep' PR" section with a checklist to ensure the repository is ready for release, including updating the changelog, bumping versions, and verifying CI status.

**Manual publishing process:**

* Broke down the manual publishing steps into clear, numbered subsections for updating the changelog, bumping versions, building/testing, tagging, creating a GitHub Release, and manual npm publishing if needed. [[1]](diffhunk://#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785dL70-R126) [[2]](diffhunk://#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785dL102-R142)

**Versioning policy:**

* Clarified the versioning policy, especially for pre-1.0 releases, and highlighted how breaking changes are communicated.