### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2025-01-01
+## [0.1.0] - 2026-04-05
 
 ### Added
 
 - `@radish-ui/core` — initial release with `Admin`, `ListBase`, and `cn()` utility for Tailwind class merging.
 - `@radish-ui/cli` — initial release with `add`, `sync`, and `diff` commands for managing registry components.
+- `radish init` command to scaffold a new radish-ui react-admin project.
+- `radish new` command to scaffold a new radish-ui react-admin project from a template.
+- `radish list` command to show available and installed components.
+- `radish remove` command for uninstalling registry components.
 - Registry components: `layout`, `datagrid`, `list`, `pagination`, `show`, `edit`, `create`, `text-field`, `boolean-field`, `number-field`, `date-field`, `edit-button`, `delete-button`, `create-button`, `simple-form`.
-- Storybook integration for developing registry components in isolation.
-- Demo app (`apps/demo`) showing a working admin panel with zero Material UI.
+- Additional registry components: `filter-button`, `search-input`, `reference`, `tabs`, `confirm-dialog`, `bulk-actions-toolbar`, `bulk-delete-button`, `export-button`.
+- `ErrorBoundary` registry component for graceful error handling.
+- `notification` registry component for mutation feedback toasts.
+- Accessible skeleton loading states for core registry components.
+- Tailwind preset (`@radish-ui/core/preset`) with semantic design tokens (surface, status, and full `canvas` color scale).
+- Dark mode support across all registry components.
+- i18n support: registry component strings are resolved through React Admin's i18n context; `radishMessages` exported from `@radish-ui/core` with default English strings under the `radish.*` namespace.
+- WCAG/ARIA improvements across all registry components (semantic HTML, `aria-current`, `aria-expanded`, `NavLink` for menus).
+- Storybook 10 integration for developing registry components in isolation.
+- Demo app (`apps/demo`) showing a working admin panel with zero Material UI, hosted at `/radish-ui/demo/` on GitHub Pages.
+- Static documentation site and hosted registry on GitHub Pages.
 - `radish.json` configuration file support for CLI.
 - `radish.lock.json` lock file to track which registry version each component file came from.
-- Remote registry support (http/https) in the CLI.
+- Remote registry support (http/https) in the CLI; default registry URL points to the hosted GitHub Pages registry (`https://saebyn.github.io/radish-ui/registry`).
+- CI check to validate `registry.json` and lockfile integrity.
+- Prop parity tests for registry components against their react-admin MUI equivalents.
+- Unit/integration tests for all registry components (97 tests across 11 files).
+- Playwright end-to-end tests for the demo app.
+- Automated dependency updates via Dependabot.
+- pnpm catalog for shared dependency version management across the monorepo.
+
+### Changed
+
+- `radish sync` now also installs newly added component files (not only updates existing ones).
+
+### Fixed
+
+- Path traversal guard: output directory is validated to ensure it cannot escape the project root.
 
 [Unreleased]: https://github.com/saebyn/radish-ui/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/saebyn/radish-ui/releases/tag/v0.1.0

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radish-ui/cli",
-  "version": "0.1.0-prerelease",
+  "version": "0.1.0",
   "description": "CLI for copying radish-ui registry components into your project",
   "keywords": [
     "cli",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radish-ui/core",
-  "version": "0.1.0-prerelease",
+  "version": "0.1.0",
   "description": "Headless react-admin wrappers and Tailwind utilities for radish-ui",
   "keywords": [
     "components",


### PR DESCRIPTION
## Release prep for v0.1.0

This is the release prep PR per the process described in [RELEASING.md](./RELEASING.md).

### Checklist

- [x] `CHANGELOG.md` updated — `[0.1.0]` section filled in with full history
- [x] `packages/core/package.json` bumped from `0.1.0-prerelease` → `0.1.0`
- [x] `packages/cli/package.json` bumped from `0.1.0-prerelease` → `0.1.0`

Once this is merged, create a GitHub Release tagged `v0.1.0` to trigger the automated npm publish workflow.