### PR TITLE
Clarify 'component' argument in CLI diff command

### DIFF
--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -125,14 +125,14 @@ Show a diff between a component in your project and the current registry
 version.
 
 ```
-radish diff <component> [options]
+radish diff [component] [options]
 ```
 
 **Arguments:**
 
-| Argument    | Description                      |
-| ----------- | -------------------------------- |
-| `component` | Name of the component to compare |
+| Argument    | Description                                         |
+| ----------- | --------------------------------------------------- |
+| `component` | Name of the component to compare, or all if omitted |
 
 **Options:**
 
@@ -146,6 +146,11 @@ radish diff <component> [options]
 ```bash
 # Show diff for the datagrid component
 npx @radish-ui/cli diff datagrid
+```
+
+```bash
+# Show diff for all components in use
+npx @radish-ui/cli diff
 ```
 
 ---

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -121,8 +121,7 @@ npx @radish-ui/cli sync --force
 
 ### `radish diff`
 
-Show a diff between a component in your project and the current registry
-version.
+Show a diff between a component in your project and the current registry version, or check drift status for all components listed in `radish.lock.json`.
 
 ```
 radish diff [component] [options]
@@ -132,7 +131,7 @@ radish diff [component] [options]
 
 | Argument    | Description                                         |
 | ----------- | --------------------------------------------------- |
-| `component` | Name of the component to compare, or all if omitted |
+| `component` | Name of the component to diff. If omitted, prints drift status for each component in `radish.lock.json` without outputting a patch. |
 
 **Options:**
 
@@ -149,7 +148,7 @@ npx @radish-ui/cli diff datagrid
 ```
 
 ```bash
-# Show diff for all components in use
+# Show drift status for all components in radish.lock.json
 npx @radish-ui/cli diff
 ```
 

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -129,9 +129,9 @@ radish diff [component] [options]
 
 **Arguments:**
 
-| Argument    | Description                                         |
-| ----------- | --------------------------------------------------- |
-| `component` | Name of the component to diff. If omitted, prints drift status for each component in `radish.lock.json` without outputting a patch. |
+| Argument    | Description                                                                      |
+| ----------- | -------------------------------------------------------------------------------- |
+| `component` | Component to diff. If omitted, prints a drift status summary for each component. |
 
 **Options:**
 


### PR DESCRIPTION
Updated the CLI documentation to clarify the 'component' argument usage and added an example for showing diffs for all components.