### PR TITLE
fix(docs): prevent navbar from overlapping canary banner

### DIFF
--- a/apps/docs/.vitepress/theme/NextBanner.vue
+++ b/apps/docs/.vitepress/theme/NextBanner.vue
@@ -21,10 +21,11 @@
 <script setup lang="ts">
 declare const __IS_NEXT__: boolean;
 const isNext = __IS_NEXT__;
+const layoutTopHeight = isNext ? '36px' : '0px';
 </script>
 
 <style>
 :root {
-  --vp-layout-top-height: 36px;
+  --vp-layout-top-height: v-bind(layoutTopHeight);
 }
 </style>

--- a/apps/docs/.vitepress/theme/NextBanner.vue
+++ b/apps/docs/.vitepress/theme/NextBanner.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     v-if="isNext"
+    class="next-banner"
     style="
       background-color: #fbbf24;
       color: #1c1917;
@@ -21,3 +22,9 @@
 declare const __IS_NEXT__: boolean;
 const isNext = __IS_NEXT__;
 </script>
+
+<style>
+:root {
+  --vp-layout-top-height: 36px;
+}
+</style>

--- a/apps/docs/.vitepress/theme/NextBanner.vue
+++ b/apps/docs/.vitepress/theme/NextBanner.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     v-if="isNext"
-    class="next-banner"
     style="
       background-color: #fbbf24;
       color: #1c1917;
@@ -21,11 +20,10 @@
 <script setup lang="ts">
 declare const __IS_NEXT__: boolean;
 const isNext = __IS_NEXT__;
-const layoutTopHeight = isNext ? '36px' : '0px';
 </script>
 
 <style>
 :root {
-  --vp-layout-top-height: v-bind(layoutTopHeight);
+  --vp-layout-top-height: 36px;
 }
 </style>


### PR DESCRIPTION
## Problem

The canary "in-development" banner rendered via the `layout-top` slot was being overlapped by VitePress's fixed navbar, making it partially hidden.

## Fix

Set the `--vp-layout-top-height` CSS custom property to `36px` in `NextBanner.vue`. VitePress reads this variable to push the fixed navbar down by the banner's height, preventing the overlap.

The value of `36px` matches the banner's rendered height: `14px` font-size (~`20px` line-height) + `8px` top padding + `8px` bottom padding.