### PR TITLE
feat(cli): add `radish generate` command to scaffold registry components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `radish generate <ComponentName>` command to scaffold a new registry component with a stub `.tsx` file, Storybook story, and Vitest test. Updates `registry.json` and `apps/docs/guide/components.md`, runs `pnpm validate-registry` automatically, and prints next-step hints. Supports `--folder <domain>`, `--dry-run`, and `--list-folders` options.
+
 ## [0.2.0] - 2026-04-11
 
 ### Added

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { generateCommand } from "./generate.js";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(() => ({
+    status: 0,
+    pid: 1,
+    output: [],
+    stdout: Buffer.from(""),
+    stderr: Buffer.from(""),
+    signal: null,
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The real src/templates/ directory — used as the templatesDir override so
+ * tests don't need a built dist/ folder.
+ */
+const TEMPLATES_DIR = resolve(__dirname, "..", "..", "src", "templates");
+
+/**
+ * Creates a minimal monorepo-like fixture under `tmpDir`:
+ *   <tmpDir>/
+ *     packages/registry/
+ *       registry.json     (with one existing component)
+ *       src/
+ *         <all valid folders>/
+ *     apps/docs/guide/
+ *       components.md
+ */
+function createFixture(tmpDir: string): void {
+  const folders = [
+    "button",
+    "custom",
+    "detail",
+    "dialog",
+    "error-boundary",
+    "field",
+    "filter",
+    "form",
+    "layout",
+    "list",
+    "notification",
+    "reference",
+    "skeleton",
+  ];
+
+  for (const folder of folders) {
+    mkdirSync(join(tmpDir, "packages", "registry", "src", folder), { recursive: true });
+  }
+
+  writeFileSync(
+    join(tmpDir, "packages", "registry", "registry.json"),
+    `${JSON.stringify(
+      {
+        components: [
+          {
+            name: "skeleton",
+            files: ["src/skeleton/skeleton.tsx"],
+            dependencies: ["@radish-ui/core"],
+          },
+        ],
+      },
+      null,
+      2,
+    )}
+`,
+  );
+
+  mkdirSync(join(tmpDir, "apps", "docs", "guide"), { recursive: true });
+  writeFileSync(
+    join(tmpDir, "apps", "docs", "guide", "components.md"),
+    `# Available Components\n\n---\n\n## Fields\n\n### \`text-field\`\n\nA text field.\n\n**Files:** \`field/text-field.tsx\`\n\n**Dependencies:** \`@radish-ui/core\`\n\n\`\`\`bash\nnpx @radish-ui/cli add text-field\n\`\`\`\n\n---\n\n## Utilities\n\n### \`skeleton\`\n\nA skeleton loader.\n\n**Files:** \`skeleton/skeleton.tsx\`\n\n**Dependencies:** \`@radish-ui/core\`\n\n\`\`\`bash\nnpx @radish-ui/cli add skeleton\n\`\`\`\n`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "radish-generate-test-"));
+  createFixture(tmpDir);
+  // Reset the spawnSync mock before each test
+  const { spawnSync } = await import("node:child_process");
+  vi.mocked(spawnSync).mockClear();
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("generateCommand — happy path", () => {
+  it("creates all three files in the correct folder", async () => {
+    await generateCommand("MyField", {
+      folder: "field",
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+
+    const fieldDir = join(tmpDir, "packages", "registry", "src", "field");
+    expect(existsSync(join(fieldDir, "my-field.tsx"))).toBe(true);
+    expect(existsSync(join(fieldDir, "my-field.stories.tsx"))).toBe(true);
+    expect(existsSync(join(fieldDir, "my-field.test.tsx"))).toBe(true);
+  });
+
+  it("component file contains the PascalCase name and kebab import", async () => {
+    await generateCommand("MyField", {
+      folder: "field",
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+
+    const content = readFileSync(
+      join(tmpDir, "packages", "registry", "src", "field", "my-field.tsx"),
+      "utf-8",
+    );
+    expect(content).toContain("MyField");
+    expect(content).toContain("export const MyField");
+  });
+
+  it("stories file contains correct storybook title", async () => {
+    await generateCommand("MyField", {
+      folder: "field",
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+
+    const content = readFileSync(
+      join(tmpDir, "packages", "registry", "src", "field", "my-field.stories.tsx"),
+      "utf-8",
+    );
+    expect(content).toContain('title: "Field/MyField"');
+    expect(content).toContain('from "./my-field"');
+  });
+
+  it("test file contains the component name", async () => {
+    await generateCommand("MyField", {
+      folder: "field",
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+
+    const content = readFileSync(
+      join(tmpDir, "packages", "registry", "src", "field", "my-field.test.tsx"),
+      "utf-8",
+    );
+    expect(content).toContain("MyField");
+    expect(content).toContain('from "./my-field"');
+  });
+
+  it("updates registry.json with the new entry", async () => {
+    await generateCommand("MyField", {
+      folder: "field",
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+
+    const registry = JSON.parse(
+      readFileSync(join(tmpDir, "packages", "registry", "registry.json"), "utf-8"),
+    ) as { components: { name: string; files: string[]; dependencies: string[] }[] };
+
+    const entry = registry.components.find((c) => c.name === "my-field");
+    expect(entry).toBeDefined();
+    expect(entry?.files).toEqual(["src/field/my-field.tsx"]);
+    expect(entry?.dependencies).toEqual(["@radish-ui/core"]);
+  });
+
+  it("sorts registry.json components alphabetically", async () => {
+    await generateCommand("AaaComponent", {
+      folder: "field",
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+
+    const registry = JSON.parse(
+      readFileSync(join(tmpDir, "packages", "registry", "registry.json"), "utf-8"),
+    ) as { components: { name: string }[] };
+
+    const names = registry.components.map((c) => c.name);
+    const sorted = names.toSorted((a, b) => a.localeCompare(b));
+    expect(names).toEqual(sorted);
+  });
+
+  it("appends a stub to components.md in the correct section", async () => {
+    await generateCommand("MyField", {
+      folder: "field",
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+
+    const docs = readFileSync(join(tmpDir, "apps", "docs", "guide", "components.md"), "utf-8");
+    expect(docs).toContain("### `my-field`");
+    expect(docs).toContain("npx @radish-ui/cli add my-field");
+  });
+
+  it("calls spawnSync to run validate-registry", async () => {
+    const { spawnSync } = await import("node:child_process");
+    await generateCommand("MyField", {
+      folder: "field",
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+
+    expect(vi.mocked(spawnSync)).toHaveBeenCalledWith(
+      "pnpm",
+      ["validate-registry"],
+      expect.objectContaining({ cwd: tmpDir }),
+    );
+  });
+
+  it("defaults folder to 'custom' when not specified", async () => {
+    await generateCommand("MyWidget", {
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+
+    expect(existsSync(join(tmpDir, "packages", "registry", "src", "custom", "my-widget.tsx"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("generateCommand — dry-run", () => {
+  it("does not create any files", async () => {
+    await generateCommand("DryField", {
+      folder: "field",
+      dryRun: true,
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+
+    const fieldDir = join(tmpDir, "packages", "registry", "src", "field");
+    expect(existsSync(join(fieldDir, "dry-field.tsx"))).toBe(false);
+    expect(existsSync(join(fieldDir, "dry-field.stories.tsx"))).toBe(false);
+    expect(existsSync(join(fieldDir, "dry-field.test.tsx"))).toBe(false);
+  });
+
+  it("does not update registry.json", async () => {
+    const before = readFileSync(join(tmpDir, "packages", "registry", "registry.json"), "utf-8");
+    await generateCommand("DryField", {
+      folder: "field",
+      dryRun: true,
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+    const after = readFileSync(join(tmpDir, "packages", "registry", "registry.json"), "utf-8");
+    expect(after).toBe(before);
+  });
+
+  it("does not run validate-registry", async () => {
+    const { spawnSync } = await import("node:child_process");
+    await generateCommand("DryField", {
+      folder: "field",
+      dryRun: true,
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+    expect(vi.mocked(spawnSync)).not.toHaveBeenCalled();
+  });
+});
+
+describe("generateCommand — error cases", () => {
+  it("throws when packages/registry/registry.json does not exist", async () => {
+    rmSync(join(tmpDir, "packages", "registry", "registry.json"));
+    await expect(
+      generateCommand("MyField", { folder: "field", cwd: tmpDir, templatesDir: TEMPLATES_DIR }),
+    ).rejects.toThrow(/Registry not found/);
+  });
+
+  it("throws when the component name already exists in registry.json", async () => {
+    await expect(
+      generateCommand("Skeleton", { folder: "skeleton", cwd: tmpDir, templatesDir: TEMPLATES_DIR }),
+    ).rejects.toThrow(/already exists in registry/);
+  });
+
+  it("throws when an unknown folder is specified", async () => {
+    await expect(
+      generateCommand("MyField", {
+        folder: "nonexistent-folder",
+        cwd: tmpDir,
+        templatesDir: TEMPLATES_DIR,
+      }),
+    ).rejects.toThrow(/Unknown folder/);
+  });
+
+  it("throws when any of the target files already exist", async () => {
+    const fieldDir = join(tmpDir, "packages", "registry", "src", "field");
+    writeFileSync(join(fieldDir, "my-field.tsx"), "// existing");
+    await expect(
+      generateCommand("MyField", { folder: "field", cwd: tmpDir, templatesDir: TEMPLATES_DIR }),
+    ).rejects.toThrow(/already exists/);
+  });
+});
+
+describe("generateCommand — --list-folders", () => {
+  it("returns without writing files when listFolders is true", async () => {
+    await generateCommand("MyField", {
+      listFolders: true,
+      cwd: tmpDir,
+      templatesDir: TEMPLATES_DIR,
+    });
+    // No files should have been created
+    expect(existsSync(join(tmpDir, "packages", "registry", "src", "field", "my-field.tsx"))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,0 +1,309 @@
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { validateComponentName } from "../lib/registry.js";
+import { writeFileAtomic } from "../lib/fs.js";
+import { RadishError } from "../lib/errors.js";
+import { buildTokens, renderTemplate } from "../lib/templates.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * All valid registry subfolders. "custom" is the default for new components
+ * that don't yet belong to an established domain.
+ */
+export const VALID_FOLDERS = [
+  "button",
+  "custom",
+  "detail",
+  "dialog",
+  "error-boundary",
+  "field",
+  "filter",
+  "form",
+  "layout",
+  "list",
+  "notification",
+  "reference",
+  "skeleton",
+] as const;
+
+export type RegistryFolder = (typeof VALID_FOLDERS)[number];
+
+/**
+ * Maps registry folder names to the section heading in
+ * apps/docs/guide/components.md where the new stub should be inserted.
+ */
+const FOLDER_TO_SECTION: Record<string, string> = {
+  button: "## Buttons",
+  detail: "## Show / Detail",
+  dialog: "## Utilities",
+  "error-boundary": "## Utilities",
+  field: "## Fields",
+  filter: "## Fields",
+  form: "## Forms",
+  layout: "## Layout",
+  list: "## List & Datagrid",
+  notification: "## Utilities",
+  reference: "## Fields",
+  skeleton: "## Utilities",
+  custom: "## Utilities",
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GenerateOptions {
+  /** Registry subfolder to place the component in. Defaults to "custom". */
+  folder?: string;
+  /** Print what would be done without writing any files. */
+  dryRun?: boolean;
+  /** Print valid folder names and exit. */
+  listFolders?: boolean;
+  /** Override the working directory (used in tests). Defaults to process.cwd(). */
+  cwd?: string;
+  /**
+   * Override the templates directory (used in tests to point at src/templates/
+   * without a built dist/). Defaults to the dist/templates/ folder resolved
+   * via import.meta.url at runtime.
+   */
+  templatesDir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a PascalCase component name to kebab-case.
+ * e.g. "MyTextField" → "my-text-field"
+ */
+function toKebabCase(name: string): string {
+  return name
+    .replace(/([A-Z])/g, (_match, letter, offset) =>
+      offset === 0 ? letter.toLowerCase() : `-${letter.toLowerCase()}`,
+    )
+    .replace(/--+/g, "-");
+}
+
+/**
+ * Appends a new component stub into the correct section of components.md.
+ * If the target section heading is not found, appends at the end of the file.
+ */
+function appendToComponentsDocs(
+  docsPath: string,
+  kebabName: string,
+  folder: string,
+  dryRun: boolean,
+): void {
+  if (!existsSync(docsPath)) {
+    console.warn(`⚠ components.md not found at "${docsPath}" — skipping docs update.`);
+    return;
+  }
+
+  const stub = [
+    "",
+    `### \`${kebabName}\``,
+    "",
+    "TODO: describe this component.",
+    "",
+    `**Files:** \`${folder}/${kebabName}.tsx\``,
+    "",
+    "**Dependencies:** `@radish-ui/core`",
+    "",
+    "```bash",
+    `npx @radish-ui/cli add ${kebabName}`,
+    "```",
+    "",
+  ].join("\n");
+
+  if (dryRun) {
+    console.log(`  [dry-run] Would append to ${docsPath}:\n${stub}`);
+    return;
+  }
+
+  const original = readFileSync(docsPath, "utf-8");
+  const targetSection = FOLDER_TO_SECTION[folder] ?? null;
+
+  let updated: string;
+
+  if (targetSection !== null && original.includes(targetSection)) {
+    // Find the position just before the next `## ` heading after the target
+    // section, or at the end of the file if there is none.
+    const sectionIdx = original.indexOf(targetSection);
+    const nextSectionIdx = original.indexOf("\n## ", sectionIdx + targetSection.length);
+
+    if (nextSectionIdx === -1) {
+      // Target section is the last section — append before end of file.
+      updated = `${original.trimEnd()}
+${stub}`;
+    } else {
+      // Insert stub just before the next section heading.
+      const before = original.slice(0, nextSectionIdx).trimEnd();
+      const after = original.slice(nextSectionIdx).replace(/^[\n]*---[\n]*/, "");
+      updated = `${before}
+${stub}
+---
+${after}`;
+    }
+  } else {
+    // Section not found — safely append at the end.
+    updated = `${original.trimEnd()}
+${stub}`;
+  }
+
+  writeFileAtomic(resolve(docsPath, ".."), docsPath, updated, true);
+}
+
+// ---------------------------------------------------------------------------
+// Main command
+// ---------------------------------------------------------------------------
+
+export async function generateCommand(
+  componentName: string,
+  options: GenerateOptions,
+): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const folder = options.folder ?? "custom";
+  const dryRun = options.dryRun ?? false;
+
+  // --list-folders: print valid folders and exit
+  if (options.listFolders) {
+    console.log("Valid registry folders:\n");
+    for (const f of VALID_FOLDERS) {
+      console.log(`  ${f}${f === "custom" ? "  (default)" : ""}`);
+    }
+    return;
+  }
+
+  // Validate folder
+  if (!(VALID_FOLDERS as readonly string[]).includes(folder)) {
+    throw new RadishError(
+      `Unknown folder "${folder}". Valid folders: ${VALID_FOLDERS.join(", ")}\nRun with --list-folders to see all options.`,
+    );
+  }
+
+  // Validate component name (PascalCase input → derive kebab)
+  const kebabName = toKebabCase(componentName);
+  validateComponentName(kebabName);
+
+  // Resolve registry paths
+  const registryRoot = resolve(cwd, "packages", "registry");
+  const registryJsonPath = resolve(registryRoot, "registry.json");
+
+  if (!existsSync(registryJsonPath)) {
+    throw new RadishError(
+      `Registry not found at "${registryJsonPath}".\nRun this command from the radish-ui monorepo root.`,
+    );
+  }
+
+  // Check for duplicate name
+  const registryRaw = readFileSync(registryJsonPath, "utf-8");
+  const registry = JSON.parse(registryRaw) as { components: { name: string }[] };
+  if (registry.components.some((c) => c.name === kebabName)) {
+    throw new RadishError(
+      `Component "${kebabName}" already exists in registry.json. Choose a different name.`,
+    );
+  }
+
+  // Build token map and file paths
+  const tokens = buildTokens(componentName, kebabName, folder);
+  const folderDir = resolve(registryRoot, "src", folder);
+  const componentFile = resolve(folderDir, `${kebabName}.tsx`);
+  const storiesFile = resolve(folderDir, `${kebabName}.stories.tsx`);
+  const testFile = resolve(folderDir, `${kebabName}.test.tsx`);
+
+  // Check for existing files
+  for (const filePath of [componentFile, storiesFile, testFile]) {
+    if (existsSync(filePath)) {
+      throw new RadishError(
+        `File already exists: "${filePath}".\nRemove it manually before running generate again.`,
+      );
+    }
+  }
+
+  const { templatesDir } = options;
+
+  if (dryRun) {
+    console.log(`\n[dry-run] Would create the following files:\n`);
+    console.log(`  ${componentFile}`);
+    console.log(`  ${storiesFile}`);
+    console.log(`  ${testFile}`);
+    console.log(`\n[dry-run] Would add to registry.json:\n`);
+    console.log(
+      `  { name: "${kebabName}", files: ["src/${folder}/${kebabName}.tsx"], dependencies: ["@radish-ui/core"] }`,
+    );
+    const docsPath = resolve(cwd, "apps", "docs", "guide", "components.md");
+    appendToComponentsDocs(docsPath, kebabName, folder, true);
+    return;
+  }
+
+  // Write component, stories, and test files
+  const componentContent = renderTemplate("component.tsx.tmpl", tokens, templatesDir);
+  const storiesContent = renderTemplate("component.stories.tsx.tmpl", tokens, templatesDir);
+  const testContent = renderTemplate("component.test.tsx.tmpl", tokens, templatesDir);
+
+  writeFileAtomic(folderDir, componentFile, componentContent, false);
+  console.log(`✓ Created ${componentFile}`);
+
+  writeFileAtomic(folderDir, storiesFile, storiesContent, false);
+  console.log(`✓ Created ${storiesFile}`);
+
+  writeFileAtomic(folderDir, testFile, testContent, false);
+  console.log(`✓ Created ${testFile}`);
+
+  // Update registry.json
+  const newEntry = {
+    name: kebabName,
+    files: [`src/${folder}/${kebabName}.tsx`],
+    dependencies: ["@radish-ui/core"],
+  };
+  registry.components = registry.components
+    .concat([newEntry])
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+  writeFileAtomic(
+    registryRoot,
+    registryJsonPath,
+    `${JSON.stringify(registry, null, 2)}
+`,
+    true,
+  );
+  console.log(`✓ Updated registry.json (added "${kebabName}")`);
+
+  // Update components.md
+  const docsPath = resolve(cwd, "apps", "docs", "guide", "components.md");
+  appendToComponentsDocs(docsPath, kebabName, folder, false);
+  console.log(`✓ Updated components.md`);
+
+  // Run validate-registry
+  console.log(`\nRunning pnpm validate-registry…`);
+  const result = spawnSync("pnpm", ["validate-registry"], {
+    cwd,
+    stdio: "inherit",
+    shell: false,
+  });
+  if (result.status !== 0) {
+    console.warn(
+      `⚠ validate-registry exited with status ${result.status ?? "unknown"}. Review the output above.`,
+    );
+  }
+
+  // Next steps
+  console.log(`
+✓ Component "${kebabName}" scaffolded successfully.
+
+Next steps:
+  1. Implement the component in:
+       packages/registry/src/${folder}/${kebabName}.tsx
+  2. Add the component to the demo app, then wire it in:
+       pnpm --filter @radish-ui/demo radish add ${kebabName}
+       apps/demo/src/
+  3. Check prop-parity if there is an MUI equivalent:
+       packages/registry/src/prop-parity/expected-props.ts
+  4. Open Storybook to verify the story renders:
+       pnpm --filter @radish-ui/registry storybook
+`);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { diffCommand } from "./commands/diff.js";
 import { newCommand } from "./commands/new.js";
 import { initCommand } from "./commands/init.js";
 import { listCommand } from "./commands/list.js";
+import { generateCommand, VALID_FOLDERS } from "./commands/generate.js";
 import { RadishError } from "./lib/errors.js";
 import { DEFAULT_OUTPUT_DIR } from "./lib/config.js";
 
@@ -81,6 +82,19 @@ program
     "Path or URL to registry (local path or https:// URL; defaults to GitHub raw URL)",
   )
   .action(listCommand);
+
+program
+  .command("generate <ComponentName>")
+  .description(
+    "Scaffold a new registry component with a stub .tsx file, Storybook story, and Vitest test",
+  )
+  .option(
+    "--folder <domain>",
+    `Registry subfolder to place the component in (default: custom). Valid folders: ${VALID_FOLDERS.join(", ")}`,
+  )
+  .option("--dry-run", "Print what would be created without writing any files")
+  .option("--list-folders", "Print valid folder names and exit")
+  .action(generateCommand);
 
 program.parseAsync(process.argv).catch((err) => {
   if (err instanceof RadishError) {

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type TemplateTokens = Record<string, string>;
+
+/**
+ * Converts a folder name (e.g. "field") to title case (e.g. "Field").
+ * Handles hyphenated folder names like "error-boundary" → "Error Boundary".
+ */
+function toTitleCase(str: string): string {
+  return str
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/**
+ * Builds the standard token map for a new component scaffold.
+ *
+ * @param componentName - PascalCase component name, e.g. "MyField"
+ * @param kebabName     - kebab-case file name, e.g. "my-field"
+ * @param folder        - registry subfolder, e.g. "field"
+ */
+export function buildTokens(
+  componentName: string,
+  kebabName: string,
+  folder: string,
+): TemplateTokens {
+  return {
+    __COMPONENT_NAME__: componentName,
+    __KEBAB_NAME__: kebabName,
+    __FOLDER__: folder,
+    __STORYBOOK_TITLE__: `${toTitleCase(folder)}/${componentName}`,
+  };
+}
+
+/**
+ * Reads a `.tmpl` file and replaces all tokens with their values.
+ *
+ * @param templateName - File name without path, e.g. "component.tsx.tmpl"
+ * @param tokens       - Token map produced by {@link buildTokens}
+ * @param templatesDir - Override the templates directory (used in tests to
+ *                       point at `src/templates/` without a built `dist/`).
+ *                       Defaults to the same directory as the compiled
+ *                       `dist/index.js` at runtime (tsup publicDir copies
+ *                       template files flat into dist/).
+ */
+export function renderTemplate(
+  templateName: string,
+  tokens: TemplateTokens,
+  templatesDir?: string,
+): string {
+  const dir = templatesDir ?? dirname(fileURLToPath(import.meta.url));
+  const templatePath = resolve(dir, templateName);
+  let content = readFileSync(templatePath, "utf-8");
+  for (const [token, value] of Object.entries(tokens)) {
+    content = content.replaceAll(token, value);
+  }
+  return content;
+}

--- a/packages/cli/src/templates/component.stories.tsx.tmpl
+++ b/packages/cli/src/templates/component.stories.tsx.tmpl
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { __COMPONENT_NAME__ } from "./__KEBAB_NAME__";
+
+const meta: Meta<typeof __COMPONENT_NAME__> = {
+  title: "__STORYBOOK_TITLE__",
+  component: __COMPONENT_NAME__,
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof __COMPONENT_NAME__>;
+
+export const Default: Story = {
+  name: "Default",
+  args: {},
+};

--- a/packages/cli/src/templates/component.test.tsx.tmpl
+++ b/packages/cli/src/templates/component.test.tsx.tmpl
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { __COMPONENT_NAME__ } from "./__KEBAB_NAME__";
+
+describe("__COMPONENT_NAME__", () => {
+  it("renders without crashing", () => {
+    render(<__COMPONENT_NAME__ />);
+    expect(screen.getByText(/TODO/i)).toBeDefined();
+  });
+});

--- a/packages/cli/src/templates/component.tsx.tmpl
+++ b/packages/cli/src/templates/component.tsx.tmpl
@@ -1,0 +1,15 @@
+import type { FC } from "react";
+
+interface __COMPONENT_NAME__Props {
+  className?: string;
+}
+
+/**
+ * __COMPONENT_NAME__ – TODO: describe this component.
+ *
+ * Copy this file into your project and customise freely.
+ * @example <__COMPONENT_NAME__ />
+ */
+export const __COMPONENT_NAME__: FC<__COMPONENT_NAME__Props> = ({ className }) => {
+  return <div className={className}>TODO: implement __COMPONENT_NAME__</div>;
+};

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "lib": ["ES2022"],
+    "lib": ["ES2023"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2022",

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -10,4 +10,5 @@ export default defineConfig({
   banner: {
     js: "#!/usr/bin/env node",
   },
+  publicDir: "src/templates",
 });


### PR DESCRIPTION
Closes #90

- Adds `radish generate <ComponentName> --folder <folder>` command
- Scaffolds component stub, Storybook story, and Vitest test in the correct registry subfolder
- Updates packages/registry/registry.json (alphabetically sorted)
- Appends a stub entry to apps/docs/guide/components.md
- Auto-runs `pnpm validate-registry` after writing files
- Supports --dry-run (preview only) and --list-folders flags
- Uses .tmpl files copied into dist/ via tsup publicDir
- Bumps tsconfig lib to ES2023 for Array.toSorted()